### PR TITLE
Add personal comments across core modules

### DIFF
--- a/MasterPages/MasterWaitingRoomPage.qml
+++ b/MasterPages/MasterWaitingRoomPage.qml
@@ -21,6 +21,7 @@ Page {
         id: master
 
         onPeopleReceived: {
+            // Ogni volta che uno slave si registra lo porto immediatamente nel modello dei player.
             for (var i = 0; i < payload.length; ++i) {
                 var p = payload[i]
                 Players.appendMimimal(p.firstName, p.lastName, p.photo, unique_id)
@@ -48,7 +49,7 @@ Page {
     }
 
     // Sceglie quale model usare
-    readonly property var modelToUse: playersModel ? playersModel : mockModel
+    readonly property var modelToUse: playersModel ? playersModel : mockModel // fallback comodo per test rapidi
     readonly property int peopleCount: modelToUse ? modelToUse.count : 0
 
     ColumnLayout {

--- a/SlavePages/SlaveAddPersonPage.qml
+++ b/SlavePages/SlaveAddPersonPage.qml
@@ -23,6 +23,7 @@ Page {
 
     UdpSlave {
         id: slave
+        // Questo è il mio ponte verso il master: lo userò dopo aver scelto nome e foto.
     }
 
     ColumnLayout {

--- a/bidsmodel.cpp
+++ b/bidsmodel.cpp
@@ -11,6 +11,8 @@ BidsModel::BidsModel(PlayerModel *people)
     m_demoTimer.setInterval(1000);
     connect(&m_demoTimer, &QTimer::timeout, this, &BidsModel::addRandomBid);
 
+    // Lo lascio pronto ma non lo avvio di default: così posso abilitarlo solo quando serve una demo.
+
     // Avvio demo di default (disattiva se non vuoi)
 //    m_demoTimer.start();
 //    emit demoEnabledChanged();
@@ -61,6 +63,7 @@ int BidsModel::appendBid(int who, int delta, qint64 timestampMs)
     if (timestampMs < 0)
         timestampMs = QDateTime::currentMSecsSinceEpoch();
 
+    // Recupero il giocatore associato: senza di lui non posso loggare la puntata.
     Player* pl = people->getPlayerFromUniqueId(who);
     if (!pl) {
         qWarning() << "[BidsModel] Player id" << who << "non trovato";
@@ -73,7 +76,7 @@ int BidsModel::appendBid(int who, int delta, qint64 timestampMs)
     b.who         = *pl;
     b.totalAfter  = m_total + delta;
 
-    // Inseriamo in TESTA (riga 0) per avere il più recente in alto
+    // Inserisco sempre in testa così la UI mostra subito l'ultimo movimento.
     beginInsertRows(QModelIndex(), 0, 0);
     m_items.prepend(b);
     endInsertRows();
@@ -112,6 +115,7 @@ QVariantMap BidsModel::get(int row) const
 
 void BidsModel::setDemoEnabled(bool on)
 {
+    // Tengo il timer allineato allo stato richiesto così non invio eventi superflui.
     if (on == m_demoTimer.isActive()) return;
     if (on) m_demoTimer.start();
     else    m_demoTimer.stop();
@@ -120,6 +124,7 @@ void BidsModel::setDemoEnabled(bool on)
 
 void BidsModel::setDemoIntervalMs(int ms)
 {
+    // Espongo questo tweak perché durante le prove mi piace accelerare o rallentare la simulazione.
     if (ms <= 0 || ms == m_demoTimer.interval()) return;
     m_demoTimer.setInterval(ms);
     emit demoIntervalMsChanged();
@@ -134,6 +139,7 @@ void BidsModel::addRandomBid()
 //    if(m_items.size() > 3){
 //        setDemoEnabled(false);
 //    }
+    // Per ora tengo questa funzione pronta: quando mi serve una demo mi basta togliere i commenti.
 }
 
 QString BidsModel::randomName() const
@@ -152,6 +158,7 @@ QString BidsModel::randomName() const
     int i = qrand() % first.size();
     int j = qrand() % last.size();
 #endif
+    // Non serve nulla di fancy: unisco nome e cognome casuali per popolare la demo.
     return first.at(i) + " " + last.at(j);
 }
 
@@ -164,6 +171,7 @@ int BidsModel::randomDelta() const
 #else
     int k = qrand() % (int(sizeof(deltas)/sizeof(deltas[0])));
 #endif
+    // Così i rilanci sembrano realistici anche se generati a caso.
     return deltas[k];
 }
 

--- a/bidsmodel.h
+++ b/bidsmodel.h
@@ -11,6 +11,7 @@
 #include <QVector>
 #include <QDebug>
 
+// Gestisco qui lo storico delle puntate così lo posso riutilizzare lato QML.
 class BidsModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -38,6 +39,7 @@ public:
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
     // API QML
+    // Metodo principale: aggiungo una puntata con ID giocatore e importo.
     Q_INVOKABLE int appendBid(int who, int delta, qint64 timestampMs = -1);
     Q_INVOKABLE void clear();
     Q_INVOKABLE QVariantMap get(int row) const;
@@ -64,6 +66,7 @@ private:
         int     totalAfter  = 0;   // totale DOPO aver applicato delta
     };
 
+    // Tengo un puntatore al modello dei player per recuperare velocemente i nomi/foto.
     PlayerModel *people = nullptr;
 
     int currentTotal() const { return m_total; }
@@ -71,6 +74,7 @@ private:
     QVector<Bid> m_items;  // newest first (row 0)
     int m_total = 0;
 
+    // Timer interno per la modalità demo: mi torna utile per fare vedere il flusso.
     QTimer m_demoTimer;
     QString randomName() const;
     int randomDelta() const;

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+// Mi annoto gli include principali così da ricordarmi al volo chi sto esponendo in QML.
 #include "bidsmodel.h"
 #include "peoplemodel.h"
 #include "playermodel.h"
@@ -14,6 +15,7 @@ static PlayerModel * model = nullptr;
 static BidsModel * g_bids = nullptr;
 static PeopleModel * p_model = nullptr;
 
+// Singleton per le persone: mi piace centralizzare tutto qui per non duplicare istanze.
 static QObject* Get_PeopleModelProvider(QQmlEngine* engine, QJSEngine* scriptEngine) {
     Q_UNUSED(engine)
     Q_UNUSED(scriptEngine)
@@ -39,6 +41,7 @@ static QObject* Get_PlayersSingleton(QQmlEngine* engine, QJSEngine* scriptEngine
     return model;
 }
 
+// E mi salvo anche i bids nello stesso stile, così QML li usa sempre sincronizzati con i player.
 static QObject* Get_BidsProvider(QQmlEngine* engine, QJSEngine* scriptEngine)
 {
     Q_UNUSED(engine)
@@ -83,6 +86,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<UdpMaster>("Network", 1, 0, "UdpMaster");
     qmlRegisterType<UdpSlave>("Network", 1, 0, "UdpSlave");
 
+    // Engine QML principale: qui carico tutto il mondo dell'interfaccia.
     QQmlApplicationEngine engine;
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,

--- a/main.qml
+++ b/main.qml
@@ -6,12 +6,14 @@ import QtGraphicalEffects 1.12
 import "qrc:/MasterPages/"
 import "qrc:/SlavePages/"
 
+// Entry point dell'app: qui definisco finestra e flussi principali.
 ApplicationWindow {
     id: win
     visible: true
     width: 640; height: 480
     title: qsTr("FantaBet App")
 
+    // Stack principale che mi permette di saltare tra home e flussi specifici.
     StackView {
         id: rootStack
         anchors.fill: parent
@@ -31,12 +33,14 @@ ApplicationWindow {
                     width: 170; height: 190
                     iconSource: "qrc:/worker-money-time.png"
                     label: qsTr("Master")
+                    // Quando clicco qui parte il flow dedicato al banco.
                     onClicked: rootStack.push(masterFlow)
                 }
                 IconButton {
                     width: 170; height: 190
                     iconSource: "qrc:/man-with-money.png"
                     label: qsTr("Scommettitore")
+                    // E questo apre il percorso lato giocatore.
                     onClicked: rootStack.push(slaveFlow)
                 }
             }
@@ -108,6 +112,7 @@ ApplicationWindow {
             StackView {
                 id: masterStack
                 anchors.fill: parent
+                // Parto sempre dalla waiting room: da lì controllo il resto della partita.
                 initialItem: MasterWaitingRoomPage {}   // la tua pagina iniziale del flusso master
             }
         }
@@ -177,6 +182,7 @@ ApplicationWindow {
             StackView {
                 id: slaveStack
                 anchors.fill: parent
+                // Sul lato giocatore parto dalla pagina di registrazione persona.
                 initialItem: SlaveAddPersonPage {}       // la tua pagina iniziale del flusso slave
             }
         }

--- a/peoplemodel.h
+++ b/peoplemodel.h
@@ -8,12 +8,14 @@
 #include <QString>
 #include <QSettings>
 
+// Ogni persona candidata è rappresentata così: tengo anche la foto per comodità in UI.
 struct Person {
     QString firstName;
     QString lastName;
     QString photo;   // path (file:///... o qrc:/...)
 };
 
+// Modello dei possibili giocatori: lo uso per popolare la schermata di scelta rapida.
 class PeopleModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -37,13 +39,16 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     // QML API
+    // Aggiungo una nuova persona e salvo subito su disco se la persistenza è attiva.
     Q_INVOKABLE void addPerson(const QString& firstName,
                                const QString& lastName,
                                const QString& photo = QString());
     Q_INVOKABLE void removeAt(int row);
+    // Posso aggiornare singole proprietà dalla UI senza ricreare la persona.
     Q_INVOKABLE void updateAt(int row, const QVariantMap& data);
     Q_INVOKABLE void clearAll();
     Q_INVOKABLE int  indexOfByName(const QString& firstName, const QString& lastName) const;
+    // Ordinamento personalizzabile: mi torna utile quando l'elenco cresce.
     Q_INVOKABLE void sortBy(const QString& field, bool ascending = true);
     Q_INVOKABLE QByteArray toJson() const;
 
@@ -62,6 +67,7 @@ private:
     static QString fullNameOf(const QString& firstName, const QString& lastName);
 
     QVector<Person> m_items;
+    // Flag per decidere al volo se salvare su disco: comodo durante i test.
     bool m_persist = true;
 
     // persistenza

--- a/playermodel.cpp
+++ b/playermodel.cpp
@@ -4,6 +4,7 @@
 PlayerModel::PlayerModel(QObject* parent)
     : QAbstractListModel(parent)
 {
+    // Modello vuoto di partenza: preferisco popolarlo esplicitamente da QML o dal master.
 }
 
 int PlayerModel::rowCount(const QModelIndex& parent) const
@@ -28,7 +29,7 @@ QVariant PlayerModel::data(const QModelIndex& index, int role) const
     }
     case AvatarRole:     return p.avatar;
     case AccentColorRole: {
-        // Se non c'è accentColor ma c'è hue, calcola al volo
+        // Se non ho un colore esplicito mi calcolo da solo la tinta (o ne scelgo una fallback).
         QColor c = p.accentColor.isValid()
                    ? p.accentColor
                    : (p.accentHue >= 0.0 ? colorFromHue(p.accentHue)
@@ -115,6 +116,7 @@ int PlayerModel::append(const QString& firstName,
     p.lastName  = lastName;
     p.avatar    = avatar;
 
+    // Mi salvo l'hue se arriva da QML così posso rigenerare il colore in modo coerente.
     if (accentHueVar.isValid()) {
         bool ok = false;
         double h = accentHueVar.toDouble(&ok);
@@ -143,6 +145,7 @@ int PlayerModel::append(const QString& firstName,
 int PlayerModel::appendMimimal(const QString &firstName, const QString &lastName, const QString &avatar, int unique_id)
 {
     const QVariant accentColorVar;
+    // Quando popolo da rete preferisco generare un hue in base alla posizione per colori distinti.
     const QVariant accentHueVar = m_items.count() == 0 ? 0.0 : (m_items.count())*0.12;
     Player p;
     p.unique_id = unique_id;
@@ -218,6 +221,7 @@ bool PlayerModel::setAccentHue(int row, double hue01)
 
 Player *PlayerModel::getPlayerFromUniqueId(int who)
 {
+    // Mi faccio un semplice linear search: per le dimensioni del roster va più che bene.
     for (Player &p : m_items) {
         if (p.unique_id == who)
             return &p;

--- a/playermodel.h
+++ b/playermodel.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QVector>
 
+// Struct compatta per il giocatore: tengo qui tutto quello che mi serve sul lato UI.
 struct Player {
     uint32_t unique_id;
     QString firstName;
@@ -16,6 +17,7 @@ struct Player {
     double  accentHue = -1.0; // <0 = non impostata
 };
 
+// Modello esposto a QML: qui centralizzo la lista dei partecipanti che manipolo da UI.
 class PlayerModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -45,11 +47,13 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     // API comode per QML
+    // Metodo comodo per popolare tutto in un colpo solo quando costruisco il roster.
     Q_INVOKABLE int append(const QString& firstName,
                            const QString& lastName,
                            const QString& avatar = QString(),
                            const QVariant& accentColor = QVariant(),   // QColor o stringa #RRGGBB
                            const QVariant& accentHue = QVariant());    // double 0..1
+    // Variante "minimal" che uso quando il master mi fornisce già l'ID.
     Q_INVOKABLE int appendMimimal(const QString& firstName,
                            const QString& lastName,
                            const QString& avatar = QString(), int unique_id = 0);    // double 0..1
@@ -59,6 +63,7 @@ public:
     Q_INVOKABLE bool setAccentHue(int row, double hue01);              // 0..1
 
 
+    // Utility per gli altri modelli: mi serve un lookup rapido via unique_id.
     Player * getPlayerFromUniqueId(int who);
 signals:
     void countChanged();

--- a/udpmaster.h
+++ b/udpmaster.h
@@ -9,6 +9,7 @@
 #include <QElapsedTimer>
 #include <QRandomGenerator>
 
+// Ogni trasferimento "people" multi-pacchetto lo traccio qui per gestire ritrasmissioni e ack.
 struct PendingTransfer {
     int total = 0;
     int received = 0;
@@ -18,6 +19,7 @@ struct PendingTransfer {
     quint16      lastPort = 0;
 };
 
+// Questo oggetto vive nel master e gestisce la comunicazione UDP con gli slave.
 class UdpMaster : public QObject {
     Q_OBJECT
 public:
@@ -39,7 +41,9 @@ private:
     void sendNack(const QHostAddress& to, quint16 port, const QString& id,
                   const QVector<int>& missing);
     int getRandomNumber();
+    // Mappa dei trasferimenti in corso indicizzati per ID sessione inviato dallo slave.
     QMap<QString, PendingTransfer> m_transfers;
+    // Tengo a portata di mano una lista di ID nel caso volessi gestire duplicati a runtime.
     QVector<int> unique_ids_list;
 
 };

--- a/udpslave.h
+++ b/udpslave.h
@@ -12,12 +12,14 @@
 // Include PeopleModel
 #include "peoplemodel.h"
 
+// Quando invio il pacchetto "people" lo spezzo in parti e ne tengo traccia qui.
 struct OutgoingTransfer {
     QString id;
     QList<QByteArray> datagrams; // JSON già pronto (uno per seq)
     int nextToSend = 0;
 };
 
+// Oggetto creato da QML sul tablet/telefonino per parlare col master in broadcast.
 class UdpSlave : public QObject {
     Q_OBJECT
 
@@ -41,19 +43,23 @@ private slots:
 private:
     QUdpSocket m_sock;
     QTimer m_timer;
+    // Flag di stato per non bombardare il master mentre aspetto gli ACK.
     bool m_waitingAckFind = false;
     bool m_waitingAckPeople = false;
     QHostAddress m_masterAddr;
     quint16 m_masterPort = 0;
 
+    // Mi preparo il JSON completo da spezzare quando trovo il master.
     QByteArray data_to_send;
 
     static constexpr quint16 PORT = 58000;
     static constexpr int PERIOD_MS = 1000;
 
     OutgoingTransfer m_out;
+    // Timer veloce che mi permette di scaglionare l'invio dei datagrammi senza saturare la rete.
     QTimer m_burstTimer; // per pacing burst
 
+    // Una volta registrato il master mi assegna un ID che riutilizzo per le puntate.
     int unique_id = 0;
 
     void sendFind();


### PR DESCRIPTION
## Summary
- annotate the Qt entry point and QML navigation with personal notes for future reference
- add inline Italian commentary to the data models to capture reasoning about colors, persistence, and demo helpers
- document the UDP master/slave workflow and master waiting room interactions as I would explain them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c87da209448321a1bb40dc68c266fa